### PR TITLE
fixed facade namespace confussion

### DIFF
--- a/src/Laravel/LaragramServiceProvider.php
+++ b/src/Laravel/LaragramServiceProvider.php
@@ -20,7 +20,7 @@ class LaragramServiceProvider extends ServiceProvider
         $loader  = AliasLoader::getInstance();
         $aliases = Config::get('app.aliases');
         if (empty($aliases['TG'])) {
-            $loader->alias('TG', 'Williamson\Laragram\Facades\LaragramFacade');
+            $loader->alias('TG', 'Williamson\Laragram\Laravel\LaragramFacade');
         }
     }
 


### PR DESCRIPTION
Hi there! When I installed laragram, I had a problem when using the facade:

```
Class 'Williamson\Laragram\Facades\LaragramFacade' not found
```

I think this was a typo in the boot method of the `LaragramServiceProvider.php`, because the namespace of the `LaragramFacade.php` was `Williamson\Laragram\Laravel;` not `Williamson\Laragram\Facades`, as the error said. I think I fixed it :)

Anyway, I'm really new to Laravel (actually, I'm really new to php as well).... I just wanted to save you a little bit of work by making this pull request to fix this typo... if this is not a good fix, just ignore it :)

P.S.: i LOVE laragram!! awesome package bro! :D
